### PR TITLE
ipykernel 6.9.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.4.1" %}
+{% set version = "6.9.1" %}
 
 package:
   name: ipykernel
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/i/ipykernel/ipykernel-{{ version }}.tar.gz
-  sha256: df3355e5eec23126bc89767a676c5f0abfc7f4c3497d118c592b83b316e8c0cd
+  sha256: f95070a2dfd3147f8ab19f18ee46733310813758593745e07ec18fb08b409f1d
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ test:
     - trio
     {% if not migrating %}
     - ipyparallel
-    - matplotlib-base
+    - matplotlib-base  # [not (ppc64le and py==310)]
     {% endif %}
 
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,7 @@
 {% set version = "6.9.1" %}
 
+{% set migrating = false %}
+
 package:
   name: ipykernel
   version: {{ version }}
@@ -9,9 +11,8 @@ source:
   sha256: f95070a2dfd3147f8ab19f18ee46733310813758593745e07ec18fb08b409f1d
 
 build:
-  number: 1
-  # TODO: restore pypy builds https://github.com/conda-forge/ipykernel-feedstock/issues/85
-  skip: true  # [py<37 or python_impl == "pypy"]
+  number: 0
+  skip: true  # [py<37]
   script:
     - {{ PYTHON }} setup.py bdist_wheel
     - cd dist
@@ -19,48 +20,44 @@ build:
     - {{ PYTHON }} -m ipykernel install --sys-prefix
     # TODO: this may be needed/desirable at some point
     # - cd {{ RECIPE_DIR }} && {{ PYTHON }} fix_kernelspec.py
+  script_env:
+    - MIGRATING={{ migrating }}
 
 requirements:
-  {% if not win %}
-  build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - ipython >=5.0,<8.0                     # [build_platform != target_platform]
-    - jupyter_client <7.0                    # [build_platform != target_platform]
-  {% endif %}
   host:
-    - debugpy >=1,<2.0
-    - ipython >=7.23.1,<8.0
-    - ipython_genutils
-    - jupyter_client <7.0
+    - debugpy >=1.0.0,<2.0
+    - ipython >=7.23.1
+    - jupyter_client <8.0
+    - jupyter_core >=4.2
     - pip
     - python
+    - setuptools
+    - wheel
   run:
-    - argcomplete >=1.12.3  # [py<38]
     - appnope  # [osx]
-    - debugpy >=1,<2.0
-    - importlib-metadata <5  # [py<38]
-    - ipython_genutils
-    - ipython >=7.23.1,<8.0
+    - debugpy >=1.0.0,<2.0
+    - ipython >=7.23.1
     - jupyter_client <8.0
     - matplotlib-inline >=0.1.0,<0.2.0
+    - nest_asyncio
     - python
     - tornado >=4.2,<7.0
-    - traitlets >=4.1.0,<6.0
+    - traitlets >=5.1.0,<6.0
 
 test:
   requires:
     - curio  # [not win]
     - flaky
-    - ipyparallel
-    - matplotlib-base
-    - nose
     - numpy >=1.16.1  # introduced numpy.core._multiarray_umath
     - pip
     - pytest !=5.3.4
     - pytest-cov
     - pytest-timeout
     - trio
+    {% if not migrating %}
+    - ipyparallel
+    - matplotlib-base
+    {% endif %}
 
   imports:
     - ipykernel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - ipython >=7.23.1
     - jupyter_client <8.0
     - matplotlib-inline >=0.1.0,<0.2.0
-    - nest_asyncio
+    - nest-asyncio
     - python
     - tornado >=4.2,<7.0
     - traitlets >=5.1.0,<6.0


### PR DESCRIPTION
Update ipykernel to 6.9.1

Changelog: https://github.com/ipython/ipykernel/blob/v6.9.1/CHANGELOG.md
License: https://github.com/ipython/ipykernel/blob/v6.9.1/COPYING.md
Requirements: 
- https://github.com/ipython/ipykernel/blob/v6.9.1/pyproject.toml
- https://github.com/ipython/ipykernel/blob/v6.9.1/setup.py

Actions:
1. Update host and run dependencies
2. Skip matplotlib-base on ppc64le with python 3.10 (it's currently not available)
3. 