### PR TITLE
update 6.19.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - jupyter_client >=6.1.12
     - packaging
     - pip
+    - comm >=0.1
     - psutil
     - wheel
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ipykernel" %}
-{% set version = "6.15.2" %}
+{% set version = "6.19.2" %}
 
 {% set migrating = false %}
 
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e7481083b438609c9c8a22d6362e8e1bc6ec94ba0741b666941e634f2d61bdf3
+  sha256: 1ab68d3d3654196266baa93990055413e167263ffbe4cfe834f871bcd3d3506d
 
 build:
   number: 0
@@ -28,7 +28,7 @@ requirements:
     - debugpy >=1.0.0
     - hatchling >=1.4
     - ipython >=7.23.1
-    - jupyter_client >=6
+    - jupyter_client >=6.1.12
     - packaging
     - pip
     - psutil
@@ -46,13 +46,14 @@ requirements:
     - pyzmq >=17
     - tornado >=6.1,<7.0
     - traitlets >=5.1.0,<6.0
+    - comm >=0.1
 
 test:
   requires:
     - curio  # [not win]
     - flaky
     - jupyter_client
-    - numpy >=1.16.1  # introduced numpy.core._multiarray_umath
+    - numpy
     - pip
     - pytest >=6.0
     - pytest-cov

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,19 +34,19 @@ requirements:
     - psutil
     - wheel
   run:
-    - python
     - appnope  # [osx]
-    - debugpy >=1.0.0
+    - comm >=0.1
+    - debugpy >=1.0
     - ipython >=7.23.1
     - jupyter_client >=6.1.12
-    - matplotlib-inline >=0.1.0
+    - matplotlib-inline >=0.1
     - nest-asyncio
     - packaging
     - psutil
+    - python
     - pyzmq >=17
-    - tornado >=6.1,<7.0
-    - traitlets >=5.1.0,<6.0
-    - comm >=0.1
+    - tornado >=6.1
+    - traitlets >=5.1.0
 
 test:
   requires:
@@ -56,6 +56,7 @@ test:
     - numpy
     - pip
     - pytest >=6.0
+    - pytest-asyncio
     - pytest-cov
     - pytest-timeout
     - trio

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<37]
+  skip: true  # [py<38]
   script:
     - {{ PYTHON }} -m pip install . --no-deps -vv
     - {{ PYTHON }} -m ipykernel install --sys-prefix

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - wheel
   run:
     - appnope  # [osx]
-    - comm >=0.1
+    - comm >=0.1.1
     - debugpy >=1.0
     - ipython >=7.23.1
     - jupyter_client >=6.1.12
@@ -47,7 +47,7 @@ requirements:
     - python
     - pyzmq >=17
     - tornado >=6.1
-    - traitlets >=5.1.0
+    - traitlets >=5.4.0
 
 test:
   requires:
@@ -84,7 +84,7 @@ about:
     Python code in Jupyter notebooks and other interactive frontends.
   dev_url: https://github.com/ipython/ipykernel
   doc_url: https://ipython.readthedocs.io
-  doc_source_url: https://github.com/ipython/ipykernel/blob/master/docs/index.rst
+  doc_source_url: https://github.com/ipython/ipykernel/blob/main/docs/index.rst
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
# Version Bump to 6.19.2
Upstream Link: https://github.com/ipython/ipykernel
- updated sha256
- added comm as a new dependency
- updating support to python versions 3.8 and above