### PR TITLE
Update to 6.28.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,5 @@ aggregate_branch: 3.12
 
 channels:
   - https://staging.continuum.io/prefect/fs/trio-feedstock/pr4/2cd6b85
+  - https://staging.continuum.io/prefect/fs/zeromq-feedstock/pr5/4df21d3
+  - https://staging.continuum.io/prefect/fs/pyzmq-feedstock/pr13/107e723

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,4 @@
 aggregate_branch: 3.12
+
+channels:
+  - https://staging.continuum.io/prefect/fs/trio-feedstock/pr4/2cd6b85

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,1 @@
 aggregate_branch: 3.12
-
-channels:
-  - https://staging.continuum.io/prefect/fs/trio-feedstock/pr4/2cd6b85
-  - https://staging.continuum.io/prefect/fs/zeromq-feedstock/pr5/4df21d3
-  - https://staging.continuum.io/prefect/fs/pyzmq-feedstock/pr13/107e723

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,7 +72,7 @@ test:
     - jupyter kernelspec list
     - pytest -vv --color=no # [unix]
     # Skipping tests on Windows due to file and socket IO issues.
-    - pytest -vv --color=no -k "not (test_simple_print or test_init_ipc_socket or test_event_pipe_gc or test_magics or test_zmq_interactive_shell)" # [win]
+    - pytest -vv --color=no -k "not (test_sys_path or test_simple_print or test_init_ipc_socket or test_event_pipe_gc or test_magics or test_zmq_interactive_shell)" # [win]
 {% endif %}
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,7 +72,7 @@ test:
     - jupyter kernelspec list
     - pytest -vv --color=no # [unix]
     # Skipping tests on Windows due to file and socket IO issues.
-    - pytest -vv --color=no -k "not (test_init_ipc_socket or test_event_pipe_gc or test_magics or test_zmq_interactive_shell)" # [win]
+    - pytest -vv --color=no -k "not (test_simple_print or test_init_ipc_socket or test_event_pipe_gc or test_magics or test_zmq_interactive_shell)" # [win]
 {% endif %}
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ipykernel" %}
-{% set version = "6.25.0" %}
+{% set version = "6.28.0" %}
 
 {% set migrating = false %}
 
@@ -9,7 +9,9 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e342ce84712861be4b248c4a73472be4702c1b0dd77448bfd6bcfb3af9d5ddf9
+  sha256: 69c11403d26de69df02225916f916b37ea4b9af417da0a8c827f84328d88e5f3
+  patches:
+    - patches/0001-test-conf.patch
 
 build:
   number: 0
@@ -19,15 +21,11 @@ build:
     - {{ PYTHON }} -m ipykernel install --sys-prefix
     # TODO: this may be needed/desirable at some point
     # - cd {{ RECIPE_DIR }} && {{ PYTHON }} fix_kernelspec.py
-  script_env:
-    - MIGRATING={{ migrating }}
 
 requirements:
   host:
     - python
     - pip
-    - setuptools
-    - wheel
     - hatchling
     - jupyter_client >=6.1.12
     - comm >=0.1.1
@@ -45,28 +43,36 @@ requirements:
     - tornado >=6.1
     - matplotlib-inline >=0.1
     - appnope  # [osx]
-    - pyzmq >=20
+    - pyzmq >=24
     - psutil
     - packaging
 
 test:
+  source_files:
+    - pyproject.toml
+    - tests
   requires:
-    - curio  # [not win]
-    - flaky
-    - numpy
     - pip
-    - pytest >=6.0
+# There is a cyclic dependency between ipykernel and ipyparallel. 
+# Re-instate on the next update.
+{% if python != "3.12" %}
+    # test
+    - flaky
+    - pytest >=7.0
     - pytest-asyncio
     - pytest-cov
     - pytest-timeout
+    - ipyparallel 
+    # cov
     - trio
-    {% if not migrating %}
-    - ipyparallel
     - matplotlib-base
-    {% endif %}
+{% endif %}
   commands:
     - pip check
+{% if python != "3.12" %}
     - jupyter kernelspec list
+    - pytest -vv --color=no -s --cov ipykernel --cov-branch --cov-report term-missing:skip-covered --durations 10
+{% endif %}
 
 about:
   home: https://ipython.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,18 +63,16 @@ test:
     - flaky
     - pytest >=7.0
     - pytest-asyncio
-    - pytest-cov
     - pytest-timeout
     - ipyparallel 
-    # cov
-    - trio
-    - matplotlib-base
 {% endif %}
   commands:
     - pip check
 {% if python != "3.12" %}
     - jupyter kernelspec list
-    - pytest -vv --color=no -s --cov ipykernel --cov-branch --cov-report term-missing:skip-covered --durations 10
+    - pytest -vv --color=no # [unix]
+    # Skipping tests on Windows due IO issues. e.g.: An operation was attempted on something that is not a socket
+    - pytest -vv --color=no -k "not (interrupt or test_event_pipe_gc  or test_magics or test_zmq_interactive_shell)" # [win]
 {% endif %}
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,9 @@ build:
     # - cd {{ RECIPE_DIR }} && {{ PYTHON }} fix_kernelspec.py
 
 requirements:
+  build:
+    - patch # [unix]
+    - m2-patch # [win]
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,6 +72,7 @@ test:
     - jupyter kernelspec list
     - pytest -vv --color=no # [unix]
     # Skipping tests on Windows due to file and socket IO issues.
+    # test_sys_path, test_simple_print, test_init_ipc_socket, test_event_pipe_gc are intermittent
     - pytest -vv --color=no -k "not (test_sys_path or test_simple_print or test_init_ipc_socket or test_event_pipe_gc or test_magics or test_zmq_interactive_shell)" # [win]
 {% endif %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,8 +71,8 @@ test:
 {% if python != "3.12" %}
     - jupyter kernelspec list
     - pytest -vv --color=no # [unix]
-    # Skipping tests on Windows due IO issues. e.g.: An operation was attempted on something that is not a socket
-    - pytest -vv --color=no -k "not (interrupt or test_event_pipe_gc  or test_magics or test_zmq_interactive_shell)" # [win]
+    # Skipping tests on Windows due to file and socket IO issues.
+    - pytest -vv --color=no -k "not (test_init_ipc_socket or test_event_pipe_gc or test_magics or test_zmq_interactive_shell)" # [win]
 {% endif %}
 
 about:

--- a/recipe/patches/0001-test-conf.patch
+++ b/recipe/patches/0001-test-conf.patch
@@ -1,0 +1,14 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 57379b4..26481e6 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -174,6 +174,9 @@ filterwarnings= [
+ 
+   # Ignore datetime warning.
+   "ignore:datetime.datetime.utc:DeprecationWarning",
++
++  # Ignore distutils deprecation warning from appnope
++  "ignore:distutils Version classes are deprecated. Use packaging.version instead.",
+ ]
+ 
+ [tool.coverage.report]

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,12 +1,8 @@
 import json
 import os
-import pkgutil
 import platform
 import sys
 import tempfile
-
-import pytest
-
 
 def go():
     py_major = sys.version_info[0]
@@ -43,44 +39,6 @@ def go():
             "".format(spec["argv"][0], sys.executable)
         )
         sys.exit(1)
-
-    loader = pkgutil.get_loader("ipykernel.tests")
-    pytest_args = [os.path.dirname(loader.path), "-vv", "--timeout", "300"]
-
-    # coverage options
-    pytest_args += [
-        "--cov",
-        "ipykernel",
-        "--cov-report",
-        "term-missing:skip-covered",
-        "--no-cov-on-fail",
-        "--asyncio-mode=auto",
-    ]
-
-    # 2023/08/03 test_init_ipc_socket needs to be skipped due to builds getting stuck in process.
-    # see https://github.com/open-telemetry/opentelemetry-python/issues/2284
-    skips = ["flaky", "test_init_ipc_socket"]
-
-    if len(skips) == 1:
-        # 2022/8/29: CI issues on Prefect for linux platforms:
-        # The test_shutdown_subprocesses is failing has to do 
-        # with shutting down the system using process groups. 
-        # We put the entire build into a process group.
-        # It looks that the test is checking to see 
-        # that a child process or process group is shutdown after it’s requested to, but it’s not.
-        if platform.system() == "Linux":
-            skips += ["test_shutdown_subprocesses"]
-            pytest_args += ["-k", "not ({})".format(" or ".join(skips))]
-        else:
-            pytest_args += ["-k", "not {}".format(*skips)]
-    else:
-        pytest_args += ["-k", "not ({})".format(" or ".join(skips))]
-
-    print("Final pytest args:", pytest_args)
-
-    # actually run the tests
-    sys.exit(pytest.main(pytest_args))
-
 
 if __name__ == "__main__":
     if platform.system() == "Windows":


### PR DESCRIPTION
Changes:
- Update to 6.28.0
- Revamp tests to use upstream configuration.
- Add patch to upstream test configuration to ignore deprecation warning from dependency appnope.
- Comment out testing for 3.12 - there is a test dependency on ipyparallel, which itself has a run dependency on ipykernel.
- Skip some windows tests failing with IO issues.

https://github.com/ipython/ipykernel/tree/v6.28.0