### PR TITLE
build for 3.13

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
+
+channels:
+  - https://staging.continuum.io/prefect/fs/pytest-asyncio-feedstock/pr13/1658b91

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+# build_env_vars:
+#   ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
-
-channels:
-  - https://staging.continuum.io/prefect/fs/pytest-asyncio-feedstock/pr13/1658b91

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-# build_env_vars:
-#   ANACONDA_ROCKET_ENABLE_PY313 : yes
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - patches/0001-test-conf.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<38]
   script:
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
@@ -58,7 +58,7 @@ test:
     - pip
 # There is a cyclic dependency between ipykernel and ipyparallel. 
 # Re-instate on the next update.
-{% if python != "3.12" %}
+{% if python != "3.13" %}
     # test
     - flaky
     - pytest >=7.0
@@ -68,7 +68,7 @@ test:
 {% endif %}
   commands:
     - pip check
-{% if python != "3.12" %}
+{% if python != "3.13" %}
     - jupyter kernelspec list
     - pytest -vv --color=no -k "not test_interrupt_during_pdb_set_trace"  # [unix]
     # Skipping tests on Windows due to file and socket IO issues.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,16 +67,21 @@ test:
     - tests
   requires:
     - pip
+# cyclic dependency between ipykernel and ipyparallel / jupyter_client 
+{% if python != "3.13" %}
     # test
     - flaky
     - pytest >=7.0
     - pytest-asyncio
     - pytest-timeout
     #- ipyparallel 
+{% endif %}
   commands:
     - pip check
+{% if python != "3.13" %}
     - jupyter kernelspec list
     - pytest -vv --color=no -k "not ({{ tests_to_skip }})"
+{% endif %}
 
 about:
   home: https://ipython.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,31 +50,33 @@ requirements:
     - psutil
     - packaging
 
+{% set tests_to_skip = "_not_a_real_test" %}
+
+{% set tests_to_skip = tests_to_skip + " or test_interrupt_during_pdb_set_trace" %} # [unix]
+
+# Skipping tests on Windows due to file and socket IO issues.
+# test_sys_path, test_simple_print, test_init_ipc_socket, test_event_pipe_gc are intermittent
+{% set tests_to_skip = tests_to_skip + " or test_sys_path or test_simple_print or test_print_to_correct_cell or test_init_ipc_socket or test_event_pipe_gc or test_magics or test_zmq_interactive_shell" %} # [win]
+
+# Skipping tests requiring ipyparallel - There is a cyclic dependency between ipykernel and ipyparallel. 
+{% set tests_to_skip = tests_to_skip + " or test_do_apply or test_no_closure or test_generator_closure or test_nested_closure or test_closure" %}
+
 test:
   source_files:
     - pyproject.toml
     - tests
   requires:
     - pip
-# There is a cyclic dependency between ipykernel and ipyparallel. 
-# Re-instate on the next update.
-{% if python != "3.13" %}
     # test
     - flaky
     - pytest >=7.0
     - pytest-asyncio
     - pytest-timeout
-    - ipyparallel 
-{% endif %}
+    #- ipyparallel 
   commands:
     - pip check
-{% if python != "3.13" %}
     - jupyter kernelspec list
-    - pytest -vv --color=no -k "not test_interrupt_during_pdb_set_trace"  # [unix]
-    # Skipping tests on Windows due to file and socket IO issues.
-    # test_sys_path, test_simple_print, test_init_ipc_socket, test_event_pipe_gc are intermittent
-    - pytest -vv --color=no -k "not (test_sys_path or test_simple_print or test_print_to_correct_cell or test_init_ipc_socket or test_event_pipe_gc or test_magics or test_zmq_interactive_shell)" # [win]
-{% endif %}
+    - pytest -vv --color=no -k "not ({{ tests_to_skip }})"
 
 about:
   home: https://ipython.org


### PR DESCRIPTION
https://anaconda.atlassian.net/browse/PKG-6827
Rebuild for py313. Tests are skipped for 3.13 because there is a cyclic dependency between ipykernel and ipyparallel / jupyter_client. 