### PR TITLE
ipykernel 7.1.0: add support for py314

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,7 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
+
+channels: 
+  - https://staging.continuum.io/pbp/fs/matplotlib-inline-feedstock/pr4/240189b
+  - https://staging.continuum.io/pbp/fs/parso-feedstock/pr4/0534e90
+  - https://staging.continuum.io/pbp/fs/ipython-feedstock/pr50/b064335

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,6 +64,10 @@ test:
     - flaky
     - pytest >=7.0,<9
     - pytest-asyncio >=0.23.5
+    # The 6 failing tests in test_subshells.py::test_run_concurrently_sequence all fail 
+    # because the test code attempts to check for pytest's --cov option (from pytest-cov plugin) 
+    # but doesn't handle the case where the option doesn't exist, causing ValueError: no option named '--cov'.
+    - pytest-cov
     - pytest-timeout
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,11 +60,11 @@ test:
   requires:
     - pip
     # cyclic dependency between ipykernel and ipyparallel / jupyter_client
+    #- ipyparallel
     - flaky
     - pytest >=7.0,<9
     - pytest-asyncio >=0.23.5
     - pytest-timeout
-  #- ipyparallel
   commands:
     - pip check
     - jupyter kernelspec list

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,23 @@
 {% set name = "ipykernel" %}
-{% set version = "6.30.1" %}
-
-{% set migrating = false %}
+{% set version = "7.1.0" %}
+{% set migrating = "false" %}
+{% set tests_to_skip = "_not_a_real_test" %}
+{% set tests_to_skip = tests_to_skip + " or test_interrupt_during_pdb_set_trace" %}  # [unix]
+{% set tests_to_skip = tests_to_skip + " or test_sys_path or test_simple_print or test_print_to_correct_cell or test_init_ipc_socket or test_event_pipe_gc or test_magics or test_zmq_interactive_shell" %}  # [win]
+{% set tests_to_skip = tests_to_skip + " or test_lambda or test_exception or test_capture_fd or test_unicode_dict or test_subprocess_peek_at_stream_fileno or test_encode_images or test_subprocess_print" %}  # [win]
+{% set tests_to_skip = tests_to_skip + " or test_do_apply or test_no_closure or test_generator_closure or test_nested_closure or test_closure" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 6abb270161896402e76b91394fcdce5d1be5d45f456671e5080572f8505be39b
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 58a3fc88533d5930c3546dc7eac66c6d288acde4f801e2001e65edc5dc9cf0db
 
 build:
-  number: 0
-  skip: true  # [py<39]
+  number: 1
+  skip: true  # [py<310]
   script:
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
     - {{ PYTHON }} -m ipykernel install --sys-prefix
@@ -24,7 +28,7 @@ requirements:
   host:
     - python
     - pip
-    - hatchling >=1.4
+    - hatchling >=1.22
     - jupyter_client >=6
     - ipython >=7.23.1
     - comm >=0.1.1
@@ -45,31 +49,22 @@ requirements:
     - psutil >=5.7
     - packaging >=22
 
-{% set tests_to_skip = "_not_a_real_test" %}
-
-{% set tests_to_skip = tests_to_skip + " or test_interrupt_during_pdb_set_trace" %} # [unix]
-
 # Skipping tests on Windows due to file and socket IO issues.
 # test_sys_path, test_simple_print, test_init_ipc_socket, test_event_pipe_gc are intermittent
-{% set tests_to_skip = tests_to_skip + " or test_sys_path or test_simple_print or test_print_to_correct_cell or test_init_ipc_socket or test_event_pipe_gc or test_magics or test_zmq_interactive_shell" %} # [win]
 # pytest.PytestUnhandledThreadExceptionWarning: Exception in thread IOPub
-{% set tests_to_skip = tests_to_skip + " or test_lambda or test_exception or test_capture_fd or test_unicode_dict or test_subprocess_peek_at_stream_fileno or test_encode_images or test_subprocess_print" %} # [win]
-
-# Skipping tests requiring ipyparallel - There is a cyclic dependency between ipykernel and ipyparallel. 
-{% set tests_to_skip = tests_to_skip + " or test_do_apply or test_no_closure or test_generator_closure or test_nested_closure or test_closure" %}
-
+# Skipping tests requiring ipyparallel - There is a cyclic dependency between ipykernel and ipyparallel.
 test:
   source_files:
     - pyproject.toml
     - tests
   requires:
     - pip
-# cyclic dependency between ipykernel and ipyparallel / jupyter_client 
+    # cyclic dependency between ipykernel and ipyparallel / jupyter_client
     - flaky
     - pytest >=7.0,<9
-    - pytest-asyncio
+    - pytest-asyncio >=0.23.5
     - pytest-timeout
-    #- ipyparallel 
+  #- ipyparallel
   commands:
     - pip check
     - jupyter kernelspec list


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-10209) 
- [Upstream repository](ttps://github.com/ipython/ipykernel/tree/v7.1.0)

### Explanation of changes:

- Skip py<310
- Update hatchling pinning

### Notes:

-